### PR TITLE
fix: Allow `sdk.workflow(fn, arg=...)` style overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 🐛 *Bug Fixes*
 
+* `sdk.workflow(fn, resources=...)` will no longer show type errors from linters.
+
 💅 *Improvements*
 
 🥷 *Internal*

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -546,6 +546,7 @@ def workflow(
 ) -> Callable[[Callable[_P, _R]], WorkflowTemplate[_P, _R]]:
     ...
 
+
 @overload
 def workflow(
     fn: Callable[_P, _R],

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -546,6 +546,19 @@ def workflow(
 ) -> Callable[[Callable[_P, _R]], WorkflowTemplate[_P, _R]]:
     ...
 
+@overload
+def workflow(
+    fn: Callable[_P, _R],
+    *,
+    resources: Optional[_dsl.Resources] = None,
+    head_node_resources: Optional[_dsl.Resources] = None,
+    data_aggregation: Optional[Union[DataAggregation, bool]] = None,
+    custom_name: Optional[str] = None,
+    default_source_import: Optional[Import] = None,
+    default_dependency_imports: Optional[Iterable[Import]] = None,
+) -> WorkflowTemplate[_P, _R]:
+    ...
+
 
 def workflow(
     fn: Optional[Callable[_P, _R]] = None,


### PR DESCRIPTION
# The problem

Using the `sdk.workflow` decorator as a function caused typing issues when passing args

# This PR's solution

Adds a new overload such that `sdk.workflow(fn, arg=...)` doesn't show as a type error

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
